### PR TITLE
Update dependency policy and PR guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent Rules
+
+## Pull Requests
+
+- Write PR descriptions for reviewers, not as a work log.
+- Start with the future behavior or review-relevant outcome.
+- Keep the body short: summary, key changes, review focus, validation.
+- Omit local machine details unless they affect reproducibility or risk.
+- Avoid negative scope statements unless they prevent a likely review mistake.
+- Do not mention private backstory, prompts, or comparison repos.

--- a/README.md
+++ b/README.md
@@ -18,12 +18,9 @@ The site is available on [localhost:3000](http://localhost:3000/)
 ## Developing locally with wordclock
 
 ```
-"pnpm": {
-    "overrides": {
-        "@simonheys/wordclock": "file:../wordclock/packages/wordclock-js",
-        "@simonheys/wordclock-words": "file:../wordclock/packages/wordclock-words"
-    }
-}
+overrides:
+  '@simonheys/wordclock': 'file:../wordclock/packages/wordclock-js'
+  '@simonheys/wordclock-words': 'file:../wordclock/packages/wordclock-words'
 ```
 
 ## License

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,17 +1,16 @@
-# pnpm 11 requires an explicit workspace package list when workspace-level
-# settings are present. The root project is always included.
 packages:
   - '*'
 
-overrides:
-  '@types/react': 19.2.15
+pmOnFail: warn
+minimumReleaseAge: 10080
 
 minimumReleaseAgeExclude:
   - framer-motion@12.40.0
   - motion-dom@12.40.0
 
-# Keep install behavior aligned with the previous pnpm default, which did not
-# run dependency build scripts unless they were explicitly approved.
+overrides:
+  '@types/react': 19.2.15
+
 allowBuilds:
   esbuild: false
   sharp: false

--- a/renovate.json
+++ b/renovate.json
@@ -1,36 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:js-app"],
-  "schedule": ["on monday"],
+  "extends": ["config:js-app", "schedule:monthly", ":noUnscheduledUpdates"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "prCreation": "not-pending",
+  "rebaseWhen": "conflicted",
+  "stopUpdatingLabel": "stop-updating",
   "packageRules": [
     {
-      "description": "Keep framework and toolchain updates out of the broad app dependency batch.",
       "matchUpdateTypes": ["minor", "patch"],
-      "matchPackageNames": [
-        "*",
-        "!next",
-        "!react",
-        "!react-dom",
-        "!typescript",
-        "!eslint",
-        "!eslint-config-next",
-        "!lint-staged",
-        "!jest",
-        "!jest-environment-jsdom",
-        "!@playwright/test",
-        "!pnpm",
-        "!pnpm/action-setup",
-        "!postcss",
-        "!tailwindcss",
-        "!/^@testing-library\\//",
-        "!/^@tsconfig\\/node/",
-        "!/^@typescript-eslint\\//",
-        "!/^@tailwindcss\\//",
-        "!/^eslint-plugin-/",
-        "!/^prettier-plugin-/"
-      ],
-      "groupName": "all minor and patch app dependencies",
-      "groupSlug": "all-minor-patch-app"
+      "groupName": "all minor and patch dependencies",
+      "groupSlug": "all-minor-patch"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Make dependency update PRs less noisy and add terse local rules for future agent-authored PR descriptions.

## Changes

- Renovate now runs monthly, skips unscheduled updates, waits 7 days for releases, waits for pending checks, and only rebases conflicted PRs.
- pnpm now applies the same 7-day release-age gate with `minimumReleaseAge: 10080` and uses `pmOnFail: warn`.
- `AGENTS.md` now tells local agents to keep PR descriptions reviewer-facing, brief, machine-neutral, and free of private backstory.
- The wordclock local-development example now uses `pnpm-workspace.yaml` override syntax.

## Review Focus

Check `renovate.json` and `pnpm-workspace.yaml` for policy behavior, then skim `AGENTS.md` for the PR-writing rules.

## Validation

Parsed JSON/YAML, ran `git diff --check origin/develop...HEAD`, confirmed pnpm reads the new settings, and checked formatting for the touched docs/config files.
